### PR TITLE
fix(github-actions): pr_update should not execute on duplicate actions

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -95,8 +95,8 @@ jobs:
 
   pr_update:
     name: Pull request update
-    if: always()
-    needs: deploy
+    if: always() && needs.pre_job.outputs.should_skip != 'true'
+    needs: [pre_job, deploy]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
pr_update job should be skipped if duplicate actions decides to skip the entire workflow