### PR TITLE
build(deps): bump quarkus.platform.version

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -68,7 +68,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.0.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.0.2.Final</quarkus.platform.version>
     <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0</surefire-plugin.version>


### PR DESCRIPTION
Bumps `quarkus.platform.version` from 3.0.1.Final to 3.0.2.Final.

Updates `quarkus-bom` from 3.0.1.Final to 3.0.2.Final
- [Release notes](https://github.com/quarkusio/quarkus-platform/releases)
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.0.1.Final...3.0.2.Final)

Updates `quarkus-maven-plugin` from 3.0.1.Final to 3.0.2.Final
- [Release notes](https://github.com/quarkusio/quarkus-platform/releases)
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.0.1.Final...3.0.2.Final)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-bom dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch ...