### PR TITLE
build(deps): bump quarkus.platform.version from 3.2.4.Final to 3.3.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -68,7 +68,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.2.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.3.0</quarkus.platform.version>
     <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -70,6 +70,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.3.0</quarkus.platform.version>
     <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
+    <org.bouncycastle-bcprov.version>1.76</org.bouncycastle-bcprov.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <deploy-plugin.version>3.1.1</deploy-plugin.version>
@@ -126,6 +127,12 @@
         <groupId>org.mapstruct</groupId>
         <artifactId>mapstruct</artifactId>
         <version>${org.mapstruct.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>${org.bouncycastle-bcprov.version}</version>
       </dependency>
 
       <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -144,6 +144,11 @@
       <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
Bumps `quarkus.platform.version` from 3.2.4.Final to 3.3.0.

Updates `io.quarkus.platform:quarkus-bom` from 3.2.4.Final to 3.3.0
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.2.4.Final...3.3.0)

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.2.4.Final to 3.3.0
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.2.4.Final...3.3.0)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-bom dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-minor ...